### PR TITLE
Async trigger not failing if event is disposed in between.

### DIFF
--- a/ventage.js
+++ b/ventage.js
@@ -78,7 +78,9 @@
       var self = this;
       if (async) {
         setTimeout(function () {
-          self.callback.apply(self.context, args);
+          if (self.callback) {
+            self.callback.apply(self.context, args);
+          }
         }, 0);
       } else {
         self.callback.apply(self.context, args);


### PR DESCRIPTION
I encountered a problem with async events when the event gets disposed between triggering it and executing it. This PR is fixing it by checking if the callback still exists.
